### PR TITLE
Improve image efficiency by removing apt lists

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:20.04
-RUN apt-get update
-RUN apt-get install -y unbound
+RUN apt-get update \
+    && apt-get install -y unbound \
+    && rm -rf /var/lib/apt/lists/*
 ENTRYPOINT ["/usr/sbin/unbound", "-d", "-c", "/etc/unbound/unbound.conf"]


### PR DESCRIPTION
This PR slightly improves the image efficiency by performing `apt-get update` and cleaning up the lists within the same layer.

In my local builds, image size is reduced by approx. 19% (137MB --> 111MB).

Thanks / Ευχαριστώ! :)